### PR TITLE
Method to set the access token on entity provider.

### DIFF
--- a/src/Provider/XiboEntityProvider.php
+++ b/src/Provider/XiboEntityProvider.php
@@ -67,6 +67,17 @@ class XiboEntityProvider
     {
         return $this->logger;
     }
+
+    /**
+     * Set the access token
+     *  for example, if the access token has been stored in a data store, we should not have to get a new one
+     * @param $accessToken
+     * @return $this
+     */
+    public function setAccessToken($accessToken) {
+        $this->token = $accessToken;
+        return $this;
+    }
     
     /**
      * Get Access Token
@@ -75,17 +86,18 @@ class XiboEntityProvider
      */
     private function getAccessToken()
     {
-        if ($this->provider === null)
+        if ($this->provider === null) {
             throw new EmptyProviderException();
+        }
+
         $this->getLogger()->debug('Checking Access token and requesting a new one if necessary');
+
         if ($this->token == null || $this->token->hasExpired() || $this->token->getExpires() <= time() + 10) {
             // Get and store a new token
-        $this->getLogger()->info('Getting a new Access Token');
+            $this->getLogger()->info('Getting a new Access Token');
             $this->token = $this->provider->getAccessToken('client_credentials');
         }
-        else {
-            $this->token = $this->token;
-        }
+
         return $this->token;
     }
     


### PR DESCRIPTION
This is useful particularly for the auth code flow, where you will likely have stored a token after the user authorisation - you want to use this token rather than starting the flow again (which would require the user to login again, etc).